### PR TITLE
View datasets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # cartodb/Makefile
 
 EXTENSION = cartodb
-EXTVERSION = 0.18.5
+EXTVERSION = 0.18.6
 
 SED = sed
 
@@ -79,6 +79,7 @@ UPGRADABLE = \
   0.18.3 \
   0.18.4 \
   0.18.5 \
+  0.18.6 \
   $(EXTVERSION)dev \
   $(EXTVERSION)next \
   $(END)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+0.18.6 (2018-02-15)
+
+* Support user datasets stored as views instead of tables
+  * Ability to cartodbfy views with new `CDB_CartodbfyView` function
+  * Register views depending on tables in `CDB_TableMetadata` with
+    `CDB_TableMetadata_DependentViews`, `CDB_TableMetadata_Trigger`
+    functions
+  * Enable synchronizations of tables referenced by views without
+    dropping them with `CDB_TableUtils_ReplaceTableContents`
+* Fix erroneous timestamps in `CDB_TableMetadata_Text`
+
 0.18.5 (2016-11-30)
 
 * Add to new overview creation strategies #290

--- a/scripts-available/CDB_TableMetadata.sql
+++ b/scripts-available/CDB_TableMetadata.sql
@@ -81,7 +81,7 @@ BEGIN
     -- Ignore self dependencies
     WHERE v.oid <> dv.dependent_oid
   )
-  SELECT
+  SELECT DISTINCT
     dv.dependent_oid,
     dv.dependency_oid,
     dv.base_dependency_oid,

--- a/scripts-available/CDB_TableUtils.sql
+++ b/scripts-available/CDB_TableUtils.sql
@@ -49,10 +49,10 @@ BEGIN
 
     -- Generate insert select stmt
     EXECUTE FORMAT($q$
-      INSERT INTO %I.%I
+      INSERT INTO %I.%I ( %s )
         SELECT %s
         FROM %I
-    $q$, schema_name, dest_table_name, column_list, source_table_name);
+    $q$, schema_name, dest_table_name, column_list, column_list, source_table_name);
 
     -- 4. Drop source table
     EXECUTE FORMAT('DROP TABLE %I', source_table_name);

--- a/scripts-available/CDB_TableUtils.sql
+++ b/scripts-available/CDB_TableUtils.sql
@@ -1,0 +1,76 @@
+--
+-- Transactionally update the contents of the object identified
+-- `dest_table_name`.  The implementation of this update may vary
+-- depending on whether or not the table has objects which
+-- depend on it.  If possible, the table will be dropped and
+-- replaced with the newly imported table by renaming it in
+-- constant time.  Otherwise, a truncate insert will be performed
+-- when dropping the table is not possible because e.g. the table
+-- has dependent objects.
+--
+CREATE OR REPLACE FUNCTION public.CDB_TableUtils_ReplaceTableContents(
+  schema_name text,       -- name of destination schema
+  dest_table_name text,   -- name of existing
+  source_table_name text, -- fully qualified source table
+  swap_table_name text    -- temporary table to use for swapping
+)
+RETURNS void
+AS $$
+DECLARE
+  has_dependents boolean;
+  dest_table regclass;
+
+  column_list text;
+BEGIN
+
+  dest_table = FORMAT('%I.%I', schema_name, dest_table_name)::regclass;
+  has_dependents := EXISTS(
+    SELECT dependent_name
+    FROM public.CDB_TableMetadata_DependentViews(ARRAY[dest_table])
+  );
+
+  IF has_dependents
+  THEN
+    -- Because the table has dependents, it must be
+    -- updated through a truncate-insert as opposed
+    -- to renamed.
+
+    -- Get columns in table
+    SELECT
+      string_agg(quote_ident(a.attname), ',')
+    INTO column_list
+    FROM pg_catalog.pg_attribute a
+    WHERE a.attnum > 0
+      AND NOT a.attisdropped
+      AND a.attrelid = dest_table::oid;
+
+    -- Truncate table
+    EXECUTE FORMAT('TRUNCATE TABLE %I.%I', schema_name, dest_table_name);
+
+    -- Generate insert select stmt
+    EXECUTE FORMAT($q$
+      INSERT INTO %I.%I
+        SELECT %s
+        FROM %I
+    $q$, schema_name, dest_table_name, column_list, source_table_name);
+
+    -- 4. Drop source table
+    EXECUTE FORMAT('DROP TABLE %I', source_table_name);
+  ELSE
+    -- The table is safe to replace with the source
+    EXECUTE FORMAT($q$
+      ALTER TABLE IF EXISTS %I.%I
+        RENAME TO %I;
+
+      DROP TABLE IF EXISTS %I.%I;
+
+      ALTER TABLE IF EXISTS %I.%I
+        RENAME TO %I;
+   $q$, schema_name, dest_table_name, swap_table_name,
+        schema_name, swap_table_name,
+        schema_name, source_table_name, dest_table_name);
+  END IF;
+
+END;
+$$ LANGUAGE plpgsql;
+

--- a/scripts-enabled/CDB_TableUtils.sql
+++ b/scripts-enabled/CDB_TableUtils.sql
@@ -1,0 +1,1 @@
+../scripts-available/CDB_TableUtils.sql

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -558,14 +558,7 @@ function test_cdb_tablemetadata_dependent_views() {
             'cdb_testmember_1.some_table_a'::regclass,
             'cdb_testmember_1.some_table_b'::regclass
           ]::regclass[]
-        ) as dv(
-          dependent_oid oid,        -- oid of dependent view
-          dependency_oid oid,       -- oid of direct dependent of dependent view
-          base_dependency_oid oid,  -- oid of original table dependency of dependent view
-          dependent_name text,      -- name of dependent view
-          dependency_name text,     -- name of direct dependent of dependent view
-          base_dependency_name text -- name of original table dependency of dependent view
-        )
+        ) dv
         WHERE dv.base_dependency_name = 'cdb_testmember_1.some_table_a'
     " should "cdb_testmember_1.direct_dep_view_a|cdb_testmember_1.direct_dep_view_both|cdb_testmember_1.indirect_dep_view_a|cdb_testmember_1.indirect_dep_view_both"
 
@@ -579,14 +572,7 @@ function test_cdb_tablemetadata_dependent_views() {
             'cdb_testmember_1.some_table_a'::regclass,
             'cdb_testmember_1.some_table_b'::regclass
           ]::regclass[]
-        ) as dv(
-          dependent_oid oid,        -- oid of dependent view
-          dependency_oid oid,       -- oid of direct dependent of dependent view
-          base_dependency_oid oid,  -- oid of original table dependency of dependent view
-          dependent_name text,      -- name of dependent view
-          dependency_name text,     -- name of direct dependent of dependent view
-          base_dependency_name text -- name of original table dependency of dependent view
-        )
+        ) dv
         WHERE dv.base_dependency_name = 'cdb_testmember_1.some_table_b'
     " should "cdb_testmember_1.direct_dep_view_b|cdb_testmember_1.direct_dep_view_both|cdb_testmember_1.indirect_dep_view_b|cdb_testmember_1.indirect_dep_view_both"
 

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -180,11 +180,7 @@ function setup_database() {
     sql "CREATE EXTENSION plpythonu;"
 
     log_info "########################### BOOTSTRAP ###########################"
-    ${CMD} -d ${DATABASE} -f scripts-available/CDB_Organizations.sql
-    ${CMD} -d ${DATABASE} -f scripts-available/CDB_OverviewsSupport.sql
-    ${CMD} -d ${DATABASE} -f scripts-available/CDB_AnalysisSupport.sql
-    # trick to allow forcing a schema when loading SQL files (see: http://bit.ly/1HeLnhL)
-    ${CMD} -d ${DATABASE} -f test/extension/run_at_cartodb_schema.sql
+    sql "CREATE EXTENSION cartodb;"
 }
 
 function setup() {


### PR DESCRIPTION
# Purpose

Support user datasets implemented as views which reference other datasets.

## Cartodbifying Views

All user table go through the process of "cartodbification".  This includes ensuring the view specifies provides all required columns, namely
- `the_geom`
- `the_geom_webmercator` (which is a specific transformation of `the_geom`)
- `cartodb_id` (which must be a unique sequence)

To accomplish this task for both tables and views, the object is altered after its initial definition to meet these requirements.

The `CDB_CartodbfyView(text,regclass)` function is introduced to handle this process for views, and performs the following steps by wrapping the original view query, selecting new or different columns as needed, and redefining the view.  Specifically, it
- Adds the guaranteed unique sequence `row_number() OVER (ORDER BY 1)` to represent `cartodb_id`
  - This eclipses any `cartodb_id` specified by the original view
- Ensures that some `the_geom` column is specified
- Computes `the_geom_webmercator` from `the_geom` column if it is not specified.
  - Note that this computation may be expensive, so it is highly advantageous to select an existing `the_geom_webmercator` column if possible.

## Updates to User Tables and Dependent Views

When user tables are updated, triggers in the table metadata system maintain update timestamps used to, for example, invalidate cached results of queries.  These triggers have been enhanced to register updates to user tables as also updating the views which depend on those tables.

Since updates to view data will be introduced through updates to the underlying tables, and not to views directly as updatable views, this is handled with additional logic in table trigger, `CDB_Table_MetaData_Trigger()`, to invalidate dependent views as opposed to triggers attached directly to the view.

Views depending on a user table are given by the newly introduced function, `CDB_TableMetadata_DependentViews(regclass[])`, which determines all dependents recursively for one or more tables.

## Table Utils: Transactionally replacing table contents

The introduction of views which reference user tables causes issues when the user table dataset is synchronized.  In the past, synchronizations were implemented by importing a new version of the table, dropping the original table and replacing it with the new table.

This strategy breaks down when the original table has views which depend on it and cannot be dropped.  `CDB_TableUtils_ReplaceTableContents` is introduced to transactionally update table contents by performing a `TRUNCATE`/`INSERT` if the table has dependent views, but otherwise defaulting to the constant time `DROP`/`RENAME` strategy.

## Next Steps
- [x] Bumped version with release notes
- [x] More unit tests

