### PR TITLE
Disable per row quota check during syncs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # cartodb/Makefile
 
 EXTENSION = cartodb
-EXTVERSION = 0.18.6
+EXTVERSION = 0.18.7
 
 SED = sed
 
@@ -80,6 +80,7 @@ UPGRADABLE = \
   0.18.4 \
   0.18.5 \
   0.18.6 \
+  0.18.7 \
   $(EXTVERSION)dev \
   $(EXTVERSION)next \
   $(END)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+0.18.7 (2018-05-07)
+
+* Add flag to disable `test_quota_per_row` trigger in
+  `CDB_TableUtils_ReplaceTableContents` to prevent
+  potential deadlock
+
 0.18.6 (2018-02-15)
 
 * Support user datasets stored as views instead of tables

--- a/scripts-available/CDB_TableUtils.sql
+++ b/scripts-available/CDB_TableUtils.sql
@@ -44,6 +44,13 @@ BEGIN
       AND NOT a.attisdropped
       AND a.attrelid = dest_table::oid;
 
+    -- Disable row-wise quota check trigger for update
+    EXECUTE FORMAT(
+      'ALTER TABLE %I.%I DISABLE TRIGGER test_quota_per_row',
+      schema_name,
+      dest_table_name
+    );
+
     -- Truncate table
     EXECUTE FORMAT('TRUNCATE TABLE %I.%I', schema_name, dest_table_name);
 
@@ -53,6 +60,13 @@ BEGIN
         SELECT %s
         FROM %I
     $q$, schema_name, dest_table_name, column_list, column_list, source_table_name);
+
+    -- Reenable row-wise quota check trigger for normal behavior
+    EXECUTE FORMAT(
+      'ALTER TABLE %I.%I ENABLE TRIGGER test_quota_per_row',
+      schema_name,
+      dest_table_name
+    );
 
     -- 4. Drop source table
     EXECUTE FORMAT('DROP TABLE %I', source_table_name);

--- a/scripts-available/CDB_TableUtils.sql
+++ b/scripts-available/CDB_TableUtils.sql
@@ -9,10 +9,11 @@
 -- has dependent objects.
 --
 CREATE OR REPLACE FUNCTION public.CDB_TableUtils_ReplaceTableContents(
-  schema_name text,       -- name of destination schema
-  dest_table_name text,   -- name of existing
-  source_table_name text, -- fully qualified source table
-  swap_table_name text    -- temporary table to use for swapping
+  schema_name text,                   -- name of destination schema
+  dest_table_name text,               -- name of existing
+  source_table_name text,             -- fully qualified source table
+  swap_table_name text,               -- temporary table to use for swapping
+  disable_test_quota_per_row boolean  -- Disable per row quota check
 )
 RETURNS void
 AS $$
@@ -44,12 +45,15 @@ BEGIN
       AND NOT a.attisdropped
       AND a.attrelid = dest_table::oid;
 
-    -- Disable row-wise quota check trigger for update
-    EXECUTE FORMAT(
-      'ALTER TABLE %I.%I DISABLE TRIGGER test_quota_per_row',
-      schema_name,
-      dest_table_name
-    );
+    IF disable_test_quota_per_row
+    THEN
+      -- Disable row-wise quota check trigger for update
+      EXECUTE FORMAT(
+        'ALTER TABLE %I.%I DISABLE TRIGGER test_quota_per_row',
+        schema_name,
+        dest_table_name
+      );
+    END IF;
 
     -- Truncate table
     EXECUTE FORMAT('TRUNCATE TABLE %I.%I', schema_name, dest_table_name);
@@ -61,14 +65,17 @@ BEGIN
         FROM %I
     $q$, schema_name, dest_table_name, column_list, column_list, source_table_name);
 
-    -- Reenable row-wise quota check trigger for normal behavior
-    EXECUTE FORMAT(
-      'ALTER TABLE %I.%I ENABLE TRIGGER test_quota_per_row',
-      schema_name,
-      dest_table_name
-    );
+    IF disable_test_quota_per_row
+    THEN
+      -- Reenable row-wise quota check trigger for normal behavior
+      EXECUTE FORMAT(
+        'ALTER TABLE %I.%I ENABLE TRIGGER test_quota_per_row',
+        schema_name,
+        dest_table_name
+      );
+    END IF;
 
-    -- 4. Drop source table
+    -- Drop source table
     EXECUTE FORMAT('DROP TABLE %I', source_table_name);
   ELSE
     -- The table is safe to replace with the source
@@ -85,6 +92,29 @@ BEGIN
         schema_name, source_table_name, dest_table_name);
   END IF;
 
+END;
+$$ LANGUAGE plpgsql;
+
+--
+--  Overload of public.CDB_TableUtils_ReplaceTableContents(text, text, text, text, boolean)
+--  enabling per row quota check.
+--
+CREATE OR REPLACE FUNCTION public.CDB_TableUtils_ReplaceTableContents(
+  schema_name text,       -- name of destination schema
+  dest_table_name text,   -- name of existing
+  source_table_name text, -- fully qualified source table
+  swap_table_name text    -- temporary table to use for swapping
+)
+RETURNS void
+AS $$
+BEGIN
+  EXECUTE public.CDB_TableUtils_ReplaceTableContents(
+    schema_name,
+    dest_table_name,
+    source_table_name,
+    swap_table_name,
+    false
+  );
 END;
 $$ LANGUAGE plpgsql;
 


### PR DESCRIPTION
# Purpose

In some instances, the current logic in `CDB_TableUtils_ReplaceTableContents` for tables with view datasets may lead to deadlock issues during concurrent syncs.  Even in cases when deadlocks do not occur, significant slowness is observed.

This is not an issue in the following cases
- When syncs are not run simultaneously
- When tables being synced do not have dependent views

However, imposing a quota check after every row update is not always necessary.  The intent is to call `CDB_TableUtils_ReplaceTableContents` with the `disable_test_quota_per_row` flag behind a feature flag in the editor, so that the quota check may be disabled on a per user basis for e.g. common data users.