### PR TITLE
Support disabling all quota checks for syncs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # cartodb/Makefile
 
 EXTENSION = cartodb
-EXTVERSION = 0.18.7
+EXTVERSION = 0.18.8
 
 SED = sed
 
@@ -81,6 +81,7 @@ UPGRADABLE = \
   0.18.5 \
   0.18.6 \
   0.18.7 \
+  0.18.8 \
   $(EXTVERSION)dev \
   $(EXTVERSION)next \
   $(END)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+0.18.8 (2018-06-25)
+
+* Support disabling all quota checks in
+  `CDB_TableUtils_ReplaceTableContents`
+
 0.18.7 (2018-05-07)
 
 * Add flag to disable `test_quota_per_row` trigger in


### PR DESCRIPTION
# Purpose

This change supports disabling all quota checks during syncs for the same reasons identified in https://github.com/bloomberg/cartodb-postgresql/pull/2.  Though blocking transactions are much less likely in the per statement trigger vs the per row trigger, this prevents any such issues however unlikely.