### PR TITLE
Prevent deadlock conditions in CDB_TableMetadata_trigger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # cartodb/Makefile
 
 EXTENSION = cartodb
-EXTVERSION = 0.18.9
+EXTVERSION = 0.18.10
 
 SED = sed
 
@@ -83,6 +83,7 @@ UPGRADABLE = \
   0.18.7 \
   0.18.8 \
   0.18.9 \
+  0.18.10 \
   $(EXTVERSION)dev \
   $(EXTVERSION)next \
   $(END)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+0.18.10 (2019-01-23)
+
+* Support parallel `CDB_TableMetadata` trigger updates
+
 0.18.9 (2019-01-14)
 
 * Support disabling overviews check based on

--- a/scripts-available/CDB_TableUtils.sql
+++ b/scripts-available/CDB_TableUtils.sql
@@ -10,10 +10,10 @@
 --
 DROP FUNCTION IF EXISTS public.CDB_TableUtils_ReplaceTableContents(text,text,text,text,boolean);
 CREATE OR REPLACE FUNCTION public.CDB_TableUtils_ReplaceTableContents(
-  schema_name text,             -- name of destination schema
-  dest_table_name text,         -- name of existing
-  source_table_name text,       -- fully qualified source table
-  swap_table_name text,         -- temporary table to use for swapping
+  schema_name text,             -- name of schema for all tables
+  dest_table_name text,         -- name of table containing current data
+  source_table_name text,       -- name of table containing replacement data
+  swap_table_name text,         -- name of temporary table to use for swapping
   disable_quota_checks boolean  -- Disable quota check
 )
 RETURNS void
@@ -75,8 +75,8 @@ BEGIN
     EXECUTE FORMAT($q$
       INSERT INTO %I.%I ( %s )
         SELECT %s
-        FROM %I
-    $q$, schema_name, dest_table_name, column_list, column_list, source_table_name);
+        FROM %I.%I
+    $q$, schema_name, dest_table_name, column_list, column_list, schema_name, source_table_name);
 
     IF disable_quota_checks
     THEN
@@ -105,7 +105,7 @@ BEGIN
     );
 
     -- Drop source table
-    EXECUTE FORMAT('DROP TABLE %I', source_table_name);
+    EXECUTE FORMAT('DROP TABLE %I.%I', schema_name, source_table_name);
   ELSE
     -- The table is safe to replace with the source
     EXECUTE FORMAT($q$

--- a/test/extension/test.sh
+++ b/test/extension/test.sh
@@ -532,6 +532,105 @@ function test_cdb_tablemetadata_trigger_delete() {
 
 }
 
+function test_cdb_tablemetadatatouch_dependent_views() {
+
+    #setup user quota
+    sql cdb_testmember_1 "SELECT cartodb.CDB_SetUserQuotaInBytes('cdb_testmember_1', 1000000000);"
+    #create cartodbified tables and some views which
+    #depend on them
+    sql cdb_testmember_1 "CREATE TABLE cdb_testmember_1.some_table_a (id int);"
+    sql cdb_testmember_1 "CREATE TABLE cdb_testmember_1.some_table_b (id int);"
+    sql cdb_testmember_1 "SELECT cartodb.CDB_CartodbfyTable('cdb_testmember_1'::text,
+            'cdb_testmember_1.some_table_a'::regclass);"
+    sql cdb_testmember_1 "SELECT cartodb.CDB_CartodbfyTable('cdb_testmember_1'::text,
+            'cdb_testmember_1.some_table_b'::regclass);"
+
+
+    #dependents of some_table_a
+    sql cdb_testmember_1 "CREATE VIEW cdb_testmember_1.direct_dep_view_a AS
+            SELECT * FROM cdb_testmember_1.some_table_a;"
+    sql cdb_testmember_1 "CREATE VIEW cdb_testmember_1.indirect_dep_view_a AS
+            SELECT * FROM cdb_testmember_1.direct_dep_view_a;"
+
+    #dependents of some_table_b
+    sql cdb_testmember_1 "CREATE VIEW cdb_testmember_1.direct_dep_view_b AS
+            SELECT * FROM cdb_testmember_1.some_table_b;"
+    sql cdb_testmember_1 "CREATE VIEW cdb_testmember_1.indirect_dep_view_b AS
+            SELECT * FROM cdb_testmember_1.direct_dep_view_b;"
+
+    #dependents of both tables
+    sql cdb_testmember_1 "CREATE VIEW cdb_testmember_1.direct_dep_view_both AS
+            SELECT a.* FROM cdb_testmember_1.some_table_a a
+            JOIN cdb_testmember_1.some_table_b b on b.id = a.id;"
+    sql cdb_testmember_1 "CREATE VIEW cdb_testmember_1.indirect_dep_view_both AS
+            SELECT a.* FROM cdb_testmember_1.indirect_dep_view_a a
+            JOIN cdb_testmember_1.indirect_dep_view_b b on b.id = a.id;"
+
+
+    #clean up old touches
+    sql postgres "DELETE FROM cdb_tablemetadata;"
+    sql postgres "SELECT COUNT(1) FROM cdb_tablemetadata_text;" should "0"
+
+    #touch table a
+    sql postgres "SELECT cartodb.CDB_TableMetadataTouch('cdb_testmember_1.some_table_a'::regclass);"
+
+    #ensure dependents have exactly the same updated timestamps as base table
+    sql postgres "SELECT v.* FROM cartodb.cdb_tablemetadata_text v
+                  LEFT JOIN cartodb.cdb_tablemetadata_text t
+                      ON t.tabname = 'cdb_testmember_1.some_table_a'
+                  WHERE v.tabname IN('cdb_testmember_1.indirect_dep_view_both',
+                                     'cdb_testmember_1.direct_dep_view_both',
+                                     'cdb_testmember_1.indirect_dep_view_a',
+                                     'cdb_testmember_1.direct_dep_view_a')
+                    -- timestamps are not equal
+                    AND ((t.updated_at IS NOT NULL AND v.updated_at IS NULL)
+                      OR (v.updated_at IS NOT NULL AND t.updated_at IS NULL)
+                      OR (v.updated_at <> t.updated_at));" should ""
+
+    #touch table b
+    sql postgres "SELECT cartodb.CDB_TableMetadataTouch('cdb_testmember_1.some_table_b'::regclass);"
+
+    #ensure dependents have exactly the same updated timestamps as base table
+    sql postgres "SELECT v.* FROM cartodb.cdb_tablemetadata_text v
+                  LEFT JOIN cartodb.cdb_tablemetadata_text t
+                      ON t.tabname = 'cdb_testmember_1.some_table_b'
+                  WHERE v.tabname IN('cdb_testmember_1.indirect_dep_view_both',
+                                     'cdb_testmember_1.direct_dep_view_both',
+                                     'cdb_testmember_1.indirect_dep_view_b',
+                                     'cdb_testmember_1.direct_dep_view_b')
+                    -- timestamps are not equal
+                    AND ((t.updated_at IS NOT NULL AND v.updated_at IS NULL)
+                      OR (v.updated_at IS NOT NULL AND t.updated_at IS NULL)
+                      OR (v.updated_at <> t.updated_at));" should ""
+
+    #ensure views and tables exist in cdb_tablemetadata_text
+    sql postgres "SELECT COUNT(DISTINCT tabname) FROM cdb_tablemetadata_text
+                  WHERE tabname IN('cdb_testmember_1.indirect_dep_view_both',
+                                   'cdb_testmember_1.direct_dep_view_both',
+                                   'cdb_testmember_1.indirect_dep_view_b',
+                                   'cdb_testmember_1.direct_dep_view_b',
+                                   'cdb_testmember_1.indirect_dep_view_a',
+                                   'cdb_testmember_1.direct_dep_view_a',
+                                   'cdb_testmember_1.some_table_a',
+                                   'cdb_testmember_1.some_table_b');" should "8"
+
+    #ensure views and tables have exactly one record
+    sql postgres "SELECT COUNT(1) FROM (SELECT 1 FROM cdb_tablemetadata_text
+                  GROUP BY tabname HAVING COUNT(1) > 1) s;" should "0"
+
+    #cleanup
+    sql postgres "DELETE FROM cdb_tablemetadata;"
+    sql cdb_testmember_1 "DROP VIEW cdb_testmember_1.indirect_dep_view_both;"
+    sql cdb_testmember_1 "DROP VIEW cdb_testmember_1.direct_dep_view_both;"
+    sql cdb_testmember_1 "DROP VIEW cdb_testmember_1.indirect_dep_view_b;"
+    sql cdb_testmember_1 "DROP VIEW cdb_testmember_1.direct_dep_view_b;"
+    sql cdb_testmember_1 "DROP VIEW cdb_testmember_1.indirect_dep_view_a;"
+    sql cdb_testmember_1 "DROP VIEW cdb_testmember_1.direct_dep_view_a;"
+    sql cdb_testmember_1 "DROP TABLE cdb_testmember_1.some_table_b;"
+    sql cdb_testmember_1 "DROP TABLE cdb_testmember_1.some_table_a;"
+
+}
+
 function test_cdb_tablemetadata_trigger_dependent_views() {
 
     #setup user quota


### PR DESCRIPTION
The previous implementation of both deletions from
and updates to `CDB_TableMetadata` is vulnerable to
deadlock due to the undefined order in which clients
may aquire locks on rows to update or delete.  The
PostgreSQL documentation recommends the `FOR UPDATE`
statement to solve this issue:

https://www.postgresql.org/docs/current/explicit-locking.html#LOCKING-ROWS

Additionally, the procedure for insertion of records
into `CDB_TableMetadata` is also modified as part of
this change.  Since multiple clients can generate the
same rows to insert without acquiring locks on those
rows, there is an additional check added to ensure
no rows already present in the table are inserted.

An additional deadlock condition, in which the update
trigger as well as the truncate statement, both seem
to require conflicting locks on the relation being
truncated. The actual content of the trigger, however,
should not depend on the table itself.  Thus the logic
is factored into `CDB_TableMetadataTouch` and called
directly by `CDB_TableUtils_ReplaceTableContents`.